### PR TITLE
Add CSS style sheet with @font-face declaration

### DIFF
--- a/webfonts/LindenHill.css
+++ b/webfonts/LindenHill.css
@@ -11,6 +11,7 @@
 @font-face {
   font-family: 'Linden Hill';
   font-style: normal; /* Roman (Regular) */
+  src: url('LindenHill-webfont.eot'),
   src: url('LindenHill-webfont.eot?#iefix') format('embedded-opentype'),
        url('LindenHill-webfont.woff') format('woff'),
        url('LindenHill-webfont.ttf')  format('truetype'),
@@ -20,6 +21,7 @@
 @font-face {
   font-family: 'Linden Hill';
   font-style: italic;
+  src: url('LindenHill-Italic-webfont.eot'),
   src: url('LindenHill-Italic-webfont.eot?#iefix') format('embedded-opentype'),
        url('LindenHill-Italic-webfont.woff') format('woff'),
        url('LindenHill-Italic-webfont.ttf')  format('truetype'),

--- a/webfonts/LindenHill.css
+++ b/webfonts/LindenHill.css
@@ -11,7 +11,7 @@
 @font-face {
   font-family: 'Linden Hill';
   font-style: normal; /* Roman (Regular) */
-  src: url('LindenHill-webfont.eot'),
+  src: url('LindenHill-webfont.eot');
   src: url('LindenHill-webfont.eot?#iefix') format('embedded-opentype'),
        url('LindenHill-webfont.woff') format('woff'),
        url('LindenHill-webfont.ttf')  format('truetype'),
@@ -21,7 +21,7 @@
 @font-face {
   font-family: 'Linden Hill';
   font-style: italic;
-  src: url('LindenHill-Italic-webfont.eot'),
+  src: url('LindenHill-Italic-webfont.eot');
   src: url('LindenHill-Italic-webfont.eot?#iefix') format('embedded-opentype'),
        url('LindenHill-Italic-webfont.woff') format('woff'),
        url('LindenHill-Italic-webfont.ttf')  format('truetype'),

--- a/webfonts/LindenHill.css
+++ b/webfonts/LindenHill.css
@@ -1,0 +1,27 @@
+/*
+  'Linden Hill'
+  https://www.theleagueofmoveabletype.com/linden-hill
+
+  Copyright (c) 2010, Barry Schwartz <site-chieftain@crudfactory.com>,
+  with Reserved Font Name OFL "Linden Hill".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'Linden Hill';
+  font-style: normal; /* Roman (Regular) */
+  src: url('LindenHill-webfont.eot?#iefix') format('embedded-opentype'),
+       url('LindenHill-webfont.woff') format('woff'),
+       url('LindenHill-webfont.ttf')  format('truetype'),
+       url('LindenHill-webfont.svg#webfontrHfAltGz') format('svg');
+}
+
+@font-face {
+  font-family: 'Linden Hill';
+  font-style: italic;
+  src: url('LindenHill-Italic-webfont.eot?#iefix') format('embedded-opentype'),
+       url('LindenHill-Italic-webfont.woff') format('woff'),
+       url('LindenHill-Italic-webfont.ttf')  format('truetype'),
+       url('LindenHill-Italic-webfont.svg#webfontl96jjwdf') format('svg');
+}


### PR DESCRIPTION
The format used for the @font-face declaration is the
"Fontspring @Font-Face Syntax"[1] considered [2]
"the most simple and compatible one".

[1] The New Bulletproof @Font-Face Syntax
2011-02-03 (last updated: 2011-04-21)
http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax

[2] The @Font-Face Rule And Useful Web Font Tricks
2011-03-02, by Ralf Hermann
http://www.smashingmagazine.com/2011/03/02/the-font-face-rule-revisited-and-useful-tricks/
